### PR TITLE
Define an interface for Codefmt

### DIFF
--- a/src/document/codefmt.ml
+++ b/src/document/codefmt.ml
@@ -141,6 +141,8 @@ module Tag = struct
 end
 [@@alert "-deprecated--deprecated"]
 
+type t = Format.formatter
+
 let make () =
   let open Inline in
   let state0 = State.create () in

--- a/src/document/codefmt.ml
+++ b/src/document/codefmt.ml
@@ -180,9 +180,9 @@ let pf = Format.fprintf
 
 (** Transitory hackish API *)
 
-let elt = Tag.elt
+let elt t ppf = Tag.elt ppf t
 
-let entity e ppf = elt ppf [ inline @@ Inline.Entity e ]
+let entity e ppf = elt [ inline @@ Inline.Entity e ] ppf
 
 let ignore t ppf = Tag.ignore ppf t
 
@@ -201,8 +201,6 @@ let break i j ppf = Format.pp_print_break ppf i j
 let cut = break 0 0
 
 let sp = break 1 0
-
-let ( ! ) (pp : _ Fmt.t) x ppf = pp ppf x
 
 let rec list ?sep ~f = function
   | [] -> noop
@@ -227,7 +225,5 @@ let codeblock ?attr f = [ block ?attr @@ Block.Source (render f) ]
 let keyword keyword ppf = pf ppf "@{<keyword>%s@}" keyword
 
 module Infix = struct
-  let ( ! ) = ( ! )
-
   let ( ++ ) = ( ++ )
 end

--- a/src/document/codefmt.ml
+++ b/src/document/codefmt.ml
@@ -141,7 +141,7 @@ module Tag = struct
 end
 [@@alert "-deprecated--deprecated"]
 
-type t = Format.formatter
+type t = Format.formatter -> unit
 
 let make () =
   let open Inline in
@@ -177,8 +177,6 @@ let spf fmt =
   Format.kfprintf (fun _ -> flush ()) ppf fmt
 
 let pf = Format.fprintf
-
-(** Transitory hackish API *)
 
 let elt t ppf = Tag.elt ppf t
 

--- a/src/document/codefmt.mli
+++ b/src/document/codefmt.mli
@@ -4,7 +4,7 @@ type t
 
 val pf : t -> ('a, t, unit) format -> 'a
 
-val elt : t -> Inline.t -> unit
+val elt : Inline.t -> t -> unit
 
 val entity : Inline.entity -> t -> unit
 
@@ -37,7 +37,5 @@ val codeblock : ?attr:Class.t -> (t -> unit) -> Block.t
 val keyword : string -> t -> unit
 
 module Infix : sig
-  val ( ! ) : (t -> 'a -> unit) -> 'a -> t -> unit
-
   val ( ++ ) : (t -> unit) -> (t -> unit) -> t -> unit
 end

--- a/src/document/codefmt.mli
+++ b/src/document/codefmt.mli
@@ -1,0 +1,43 @@
+open Types
+
+type t
+
+val pf : t -> ('a, t, unit) format -> 'a
+
+val elt : t -> Inline.t -> unit
+
+val entity : Inline.entity -> t -> unit
+
+val ignore : (t -> unit) -> t -> unit
+
+val span : ?attr:string -> (t -> unit) -> t -> unit
+
+val txt : string -> t -> unit
+
+val noop : t -> unit
+
+val cut : t -> unit
+
+val sp : t -> unit
+
+val list : ?sep:(t -> unit) -> f:('a -> t -> unit) -> 'a list -> t -> unit
+
+val box_hv : (t -> unit) -> t -> unit
+
+val box_hv_no_indent : (t -> unit) -> t -> unit
+
+val render : (t -> unit) -> Source.t
+
+val code : ?attr:string list -> (t -> unit) -> Inline.t
+
+val documentedSrc : (t -> unit) -> DocumentedSrc.t
+
+val codeblock : ?attr:Class.t -> (t -> unit) -> Block.t
+
+val keyword : string -> t -> unit
+
+module Infix : sig
+  val ( ! ) : (t -> 'a -> unit) -> 'a -> t -> unit
+
+  val ( ++ ) : (t -> unit) -> (t -> unit) -> t -> unit
+end

--- a/src/document/codefmt.mli
+++ b/src/document/codefmt.mli
@@ -2,40 +2,38 @@ open Types
 
 type t
 
-val pf : t -> ('a, t, unit) format -> 'a
+val elt : Inline.t -> t
 
-val elt : Inline.t -> t -> unit
+val entity : Inline.entity -> t
 
-val entity : Inline.entity -> t -> unit
+val ignore : t -> t
 
-val ignore : (t -> unit) -> t -> unit
+val span : ?attr:string -> t -> t
 
-val span : ?attr:string -> (t -> unit) -> t -> unit
+val txt : string -> t
 
-val txt : string -> t -> unit
+val noop : t
 
-val noop : t -> unit
+val cut : t
 
-val cut : t -> unit
+val sp : t
 
-val sp : t -> unit
+val list : ?sep:t -> f:('a -> t) -> 'a list -> t
 
-val list : ?sep:(t -> unit) -> f:('a -> t -> unit) -> 'a list -> t -> unit
+val box_hv : t -> t
 
-val box_hv : (t -> unit) -> t -> unit
+val box_hv_no_indent : t -> t
 
-val box_hv_no_indent : (t -> unit) -> t -> unit
+val render : t -> Source.t
 
-val render : (t -> unit) -> Source.t
+val code : ?attr:string list -> t -> Inline.t
 
-val code : ?attr:string list -> (t -> unit) -> Inline.t
+val documentedSrc : t -> DocumentedSrc.t
 
-val documentedSrc : (t -> unit) -> DocumentedSrc.t
+val codeblock : ?attr:Class.t -> t -> Block.t
 
-val codeblock : ?attr:Class.t -> (t -> unit) -> Block.t
-
-val keyword : string -> t -> unit
+val keyword : string -> t
 
 module Infix : sig
-  val ( ++ ) : (t -> unit) -> (t -> unit) -> t -> unit
+  val ( ++ ) : t -> t -> t
 end

--- a/src/document/dune
+++ b/src/document/dune
@@ -3,4 +3,4 @@
  (public_name odoc.document)
  (instrumentation
   (backend bisect_ppx))
- (libraries odoc_model fmt fpath))
+ (libraries odoc_model fpath))

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -41,16 +41,16 @@ let make_name_from_path { Url.Path.name; parent; _ } =
   | None -> name
   | Some p -> Printf.sprintf "%s.%s" p.name name
 
-let label t ppf =
+let label t =
   match t with
-  | Odoc_model.Lang.TypeExpr.Label s -> O.pf ppf "%s" s
-  | Optional s -> O.pf ppf "?%s" s
+  | Odoc_model.Lang.TypeExpr.Label s -> O.txt s
+  | Optional s -> O.txt "?" ++ O.txt s
 
-let tag tag t ppf = O.pf ppf "@{<%s>%t@}" tag t
+let tag tag t = O.span ~attr:tag t
 
 let type_var tv = tag "type-var" (O.txt tv)
 
-let enclose ~l ~r x = O.span (fun ppf -> O.pf ppf "%s%t%s" l x r)
+let enclose ~l ~r x = O.span (O.txt l ++ x ++ O.txt r)
 
 let path p txt =
   O.elt

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -53,14 +53,14 @@ let type_var tv = tag "type-var" (O.txt tv)
 let enclose ~l ~r x = O.span (fun ppf -> O.pf ppf "%s%t%s" l x r)
 
 let path p txt =
-  !O.elt
+  O.elt
     [ inline @@ InternalLink (InternalLink.Resolved (Url.from_path p, txt)) ]
 
 let resolved p txt =
-  !O.elt [ inline @@ InternalLink (InternalLink.Resolved (p, txt)) ]
+  O.elt [ inline @@ InternalLink (InternalLink.Resolved (p, txt)) ]
 
 let unresolved txt =
-  !O.elt [ inline @@ InternalLink (InternalLink.Unresolved txt) ]
+  O.elt [ inline @@ InternalLink (InternalLink.Unresolved txt) ]
 
 let path_to_id path =
   match Url.Anchor.from_identifier (path :> Paths.Identifier.t) with

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -3,7 +3,7 @@ module Lang = Odoc_model.Lang
 
 type rendered_item = DocumentedSrc.t
 
-type text = Format.formatter -> unit
+type text = Codefmt.t -> unit
 
 (** HTML generation syntax customization module. See {!ML} and
     {!Reason}. *)

--- a/src/document/generator_signatures.ml
+++ b/src/document/generator_signatures.ml
@@ -3,7 +3,7 @@ module Lang = Odoc_model.Lang
 
 type rendered_item = DocumentedSrc.t
 
-type text = Codefmt.t -> unit
+type text = Codefmt.t
 
 (** HTML generation syntax customization module. See {!ML} and
     {!Reason}. *)


### PR DESCRIPTION
The interface is defined in such a way that the "generating" (`Generator`) code and the "rendering" (`Codefmt.render`) code don't call each other. The use of `Format` is entirely abstracted, making the interface a lot easier to use.
This allows, for example, to add a "state" argument to `Codefmt.t` (I tried something here but it didn't end well)